### PR TITLE
Fall back to using c_crossattn if y key does not exist

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -94,12 +94,12 @@ class CADS:
             c = args["c"]
 
             if noise_scale > 0.0:
-                apply_to = c.get(key, c["c_crossattn"])
+                noise_target = c.get(key, c["c_crossattn"])
                 gamma = cads_gamma(timestep)
-                for i in range(apply_to.size(dim=0)):
+                for i in range(noise_target.size(dim=0)):
                     if cond_or_uncond[i % len(cond_or_uncond)] == skip:
                         continue
-                    apply_to[i] = cads_noise(gamma, apply_to[i])
+                    noise_target[i] = cads_noise(gamma, noise_target[i])
 
             if previous_wrapper:
                 return previous_wrapper(apply_model, args)

--- a/__init__.py
+++ b/__init__.py
@@ -94,11 +94,12 @@ class CADS:
             c = args["c"]
 
             if noise_scale > 0.0:
+                apply_to = c.get(key, c["c_crossattn"])
                 gamma = cads_gamma(timestep)
-                for i in range(c[key].size(dim=0)):
+                for i in range(apply_to.size(dim=0)):
                     if cond_or_uncond[i % len(cond_or_uncond)] == skip:
                         continue
-                    c[key][i] = cads_noise(gamma, c[key][i])
+                    apply_to[i] = cads_noise(gamma, apply_to[i])
 
             if previous_wrapper:
                 return previous_wrapper(apply_model, args)


### PR DESCRIPTION
i'm not sure which models have the `y` key, but Stable Diffusion 1.5 models don't so the default key of `y` will fail. this small pull just falls back to using `c_crossattn` if the key lookup fails: it's a no-op if the key is already `c_crossattn` and will prevent failure in the case of it being set to `y` on a model like SD 1.5.